### PR TITLE
quality_control skip empty traces

### DIFF
--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -83,7 +83,11 @@ class MSEEDMetadata(object):
             # requested time span.
             if not st:
                 continue
-            self.data.extend(st.traces)
+            
+            for tr in st:
+                if(tr.stats.npts != 0):
+                    self.data.extend([tr])
+                    
             self.files.append(file)
 
         if not self.data:

--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -150,7 +150,7 @@ class MSEEDMetadata(object):
         m['sta'] = stats.station
         m['loc'] = stats.location
         m['cha'] = stats.channel
-        m['mseed_id'] = '.'.join([m['net'], m['sta'], m['loc'], m['cha']])
+        m['mseed_id'] = self.data[0].id
         m['quality'] = stats.mseed.dataquality
         m['files'] = self.files
 

--- a/obspy/signal/quality_control.py
+++ b/obspy/signal/quality_control.py
@@ -150,6 +150,7 @@ class MSEEDMetadata(object):
         m['sta'] = stats.station
         m['loc'] = stats.location
         m['cha'] = stats.channel
+        m['mseed_id'] = '.'.join([m['net'], m['sta'], m['loc'], m['cha']])
         m['quality'] = stats.mseed.dataquality
         m['files'] = self.files
 


### PR DESCRIPTION
I was trying to generate an output from a mseed file and noticed that empty traces (npts = 0) throw numpy errors. e.g. when calling np.min() on an empty array. 

```
NL.HGN.02.BHZ | 2013-12-31T23:59:58.694538Z - 2014-01-01T16:22:29.344538Z | 40.0 Hz, 2358027 samples
NL.HGN.02.BHZ | 2014-01-01T16:22:29.344500Z - 2014-01-01T16:22:29.344500Z | 40.0 Hz, 0 samples

self.meta['sample_min'] = min([tr.data.min() for tr in self.data])
ValueError: zero-size array to reduction operation minimum which has no identity
```

I think it's safe to skip all empty traces because there are no samples in it for QC statistics.
